### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/notfound.yml
+++ b/.github/workflows/notfound.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - name: Fix links


### PR DESCRIPTION
Potential fix for [https://github.com/icco/writing/security/code-scanning/28](https://github.com/icco/writing/security/code-scanning/28)

In general, fix this by adding a `permissions` key either at the workflow root (applies to all jobs) or under the specific `check` job (applies only to that job). The permissions should grant only what the workflow actually needs using the built-in `GITHUB_TOKEN`.

For this workflow, `tmcw/notfoundbot` scans repository content and typically opens pull requests with updated links. That requires at least read access to the repository contents and write access to pull requests (and often `contents: write` if it pushes branches directly). To stay aligned with least privilege while preserving existing behavior, we should add a job-level `permissions` block under `check:` with `contents: write` and `pull-requests: write`. If you know the bot only comments on PRs and doesn’t push branches, you could potentially reduce `contents` to `read`, but the safer non-breaking assumption is that it needs to modify content.

Concretely, in `.github/workflows/notfound.yml`, under `jobs:`, inside the `check` job and at the same indentation level as `runs-on:`, insert:

```yaml
    permissions:
      contents: write
      pull-requests: write
```

No extra imports or definitions are required; this is pure workflow-configuration YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
