### PR TITLE
chore(deps): bump @google/genai to ^2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@google/genai": "^1.50.1",
+    "@google/genai": "^2.0.1",
     "@heroicons/react": "^2.1.5",
     "@icco/react-common": "^2026.430.1",
     "@imgix/js-core": "^3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,10 +758,10 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz#8249de9b7e22fcb3ceb5e66090c30a1d5492b81a"
   integrity sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==
 
-"@google/genai@^1.50.1":
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-1.52.0.tgz#0dc2544b5ac93bdabfd313482d9a5c12623cbc7a"
-  integrity sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==
+"@google/genai@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-2.0.1.tgz#c98c6eaaf173b1b1f280a6d618d73e2ac28480dc"
+  integrity sha512-trxxbVePM9J8Cuni5x7+xvApoqb2y6Zk27/wugjT2cuwHOT78nFGdf/Ni29MkDxzWwrj90OQpno1Ana6dm3D2A==
   dependencies:
     google-auth-library "^10.3.0"
     p-retry "^4.6.2"


### PR DESCRIPTION
Bump `@google/genai` from `^1.50.1` to `^2.0.1`.

v2.0.0 breaking changes are [scoped to the Interactions API](https://github.com/googleapis/js-genai/blob/main/CHANGELOG.md); `prepare-posts.ts` only uses `models.generateContent`, so no code changes are required.
