### PR TITLE
feat(header): add nav icons and bump react-common to 2026.510.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@google/genai": "^1.50.1",
     "@heroicons/react": "^2.1.5",
-    "@icco/react-common": "^2026.430.1",
+    "@icco/react-common": "^2026.510.2",
     "@imgix/js-core": "^3.8.0",
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,8 +1,6 @@
 import { ImageResponse } from "next/og"
 import { NextRequest } from "next/server"
 
-export const runtime = "edge"
-
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl
   const title = searchParams.get("title") ?? "Nat Welch's Blog"

--- a/src/app/drafts/page.tsx
+++ b/src/app/drafts/page.tsx
@@ -2,13 +2,13 @@ import { compareDesc } from "date-fns"
 import { Metadata, Viewport } from "next"
 
 import { PostCard } from "@/components/PostCard"
+import { siteUrl } from "@/lib/siteUrl"
 
 import { allPosts, Post } from "contentlayer/generated"
 
-const domain = new URL(process.env.DOMAIN ?? "https://writing.natwelch.com")
 const title = `Drafts!`
 export const metadata: Metadata = {
-  metadataBase: domain,
+  metadataBase: siteUrl(),
   title,
   robots: { index: false, follow: false },
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Roboto, Roboto_Mono, Roboto_Slab } from "next/font/google"
 
 import Footer from "@/components/Footer"
 import Header from "@/components/Header"
+import { siteUrl } from "@/lib/siteUrl"
 import { ThemeProvider } from "@icco/react-common/ThemeProvider"
 import { WebVitals } from "@icco/react-common/WebVitals"
 
@@ -26,9 +27,7 @@ const robotoMono = Roboto_Mono({
 })
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.DOMAIN ?? "https://writing.natwelch.com"
-  ),
+  metadataBase: siteUrl(),
   title: "Nat? Nat. Nat!",
   description: "The personal blog of Nat Welch",
   other: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,12 @@ import { Metadata, Viewport } from "next"
 
 import { PostCard } from "@/components/PostCard"
 import publishedPosts from "@/lib/posts"
+import { siteUrl } from "@/lib/siteUrl"
 
 const title = `Nat? Nat. Nat!`
 const description = `The personal blog of Nat Welch`
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.DOMAIN ?? "https://writing.natwelch.com"
-  ),
+  metadataBase: siteUrl(),
   title,
   description,
   openGraph: {

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -21,6 +21,7 @@ import publishedPosts, {
   nextPost,
   previousPost,
 } from "@/lib/posts"
+import { siteUrl } from "@/lib/siteUrl"
 
 export const generateStaticParams = async () =>
   publishedPosts()
@@ -42,9 +43,7 @@ export const generateMetadata = async (props: {
   const imageAlt = getHeaderImageAlt(post)
 
   return {
-    metadataBase: new URL(
-      process.env.DOMAIN ?? "https://writing.natwelch.com"
-    ),
+    metadataBase: siteUrl(),
     title,
     description,
     id: post.id,

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -5,11 +5,10 @@ import Link from "next/link"
 import { allPosts, Post } from "contentlayer/generated"
 
 import publishedPosts from "@/lib/posts"
+import { siteUrl } from "@/lib/siteUrl"
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.DOMAIN ?? "https://writing.natwelch.com"
-  ),
+  metadataBase: siteUrl(),
   title: "Stats | Nat? Nat. Nat!",
   description: "Writing statistics for Nat Welch's blog",
   openGraph: {

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from "next/navigation"
 import { PostCard } from "@/components/PostCard"
 import { allTags } from "@/components/Tag"
 import publishedPosts from "@/lib/posts"
+import { siteUrl } from "@/lib/siteUrl"
 import { normalizeTag, tagAliases } from "@/lib/tagAliases"
 
 export const generateMetadata = async (props: {
@@ -15,9 +16,7 @@ export const generateMetadata = async (props: {
   const description = `All blog posts tagged #${tag} by Nat Welch`
 
   return {
-    metadataBase: new URL(
-      process.env.DOMAIN ?? "https://writing.natwelch.com"
-    ),
+    metadataBase: siteUrl(),
     title,
     description,
     openGraph: {

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next"
 
 import { allTagsWithCounts, Tag } from "@/components/Tag"
+import { siteUrl } from "@/lib/siteUrl"
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.DOMAIN ?? "https://writing.natwelch.com"
-  ),
+  metadataBase: siteUrl(),
   title: "All Tags | Nat? Nat. Nat!",
   description: "Browse all topics and tags on Nat Welch's blog",
   openGraph: {

--- a/src/app/year/[year]/page.tsx
+++ b/src/app/year/[year]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation"
 
 import { PostCard } from "@/components/PostCard"
 import publishedPosts from "@/lib/posts"
+import { siteUrl } from "@/lib/siteUrl"
 
 export const generateMetadata = async (props: {
   params: Promise<{ year: string }>
@@ -14,9 +15,7 @@ export const generateMetadata = async (props: {
   const description = `All blog posts written by Nat Welch in ${year}`
 
   return {
-    metadataBase: new URL(
-      process.env.DOMAIN ?? "https://writing.natwelch.com"
-    ),
+    metadataBase: siteUrl(),
     title,
     description,
     openGraph: {

--- a/src/app/years/page.tsx
+++ b/src/app/years/page.tsx
@@ -3,11 +3,10 @@ import type { Metadata } from "next"
 import Link from "next/link"
 
 import publishedPosts from "@/lib/posts"
+import { siteUrl } from "@/lib/siteUrl"
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.DOMAIN ?? "https://writing.natwelch.com"
-  ),
+  metadataBase: siteUrl(),
   title: "Archive by Year | Nat? Nat. Nat!",
   description: "Browse Nat Welch's blog posts by year",
   openGraph: {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,30 @@
+import {
+  ChartBarIcon,
+  InformationCircleIcon,
+  TagIcon,
+} from "@heroicons/react/24/outline"
 import { SiteHeader } from "@icco/react-common/SiteHeader"
 
 export default function Header() {
   return (
     <SiteHeader
       links={[
-        { name: "Stats", href: "/stats" },
-        { name: "Tags", href: "/tags" },
-        { name: "About", href: "/about", prefetch: false },
+        {
+          name: "Stats",
+          href: "/stats",
+          icon: <ChartBarIcon className="h-5 w-5" />,
+        },
+        {
+          name: "Tags",
+          href: "/tags",
+          icon: <TagIcon className="h-5 w-5" />,
+        },
+        {
+          name: "About",
+          href: "/about",
+          prefetch: false,
+          icon: <InformationCircleIcon className="h-5 w-5" />,
+        },
       ]}
     />
   )

--- a/src/lib/siteUrl.ts
+++ b/src/lib/siteUrl.ts
@@ -1,0 +1,6 @@
+const FALLBACK = "https://writing.natwelch.com"
+
+export function siteUrl(): URL {
+  const raw = process.env.DOMAIN ?? FALLBACK
+  return new URL(/^https?:\/\//.test(raw) ? raw : `https://${raw}`)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,9 +823,9 @@
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
 "@icco/react-common@^2026.510.2":
-  version "2026.510.2"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.510.2/148b54b2cb740bc174ba2550796c8cfa82d64a0d#148b54b2cb740bc174ba2550796c8cfa82d64a0d"
-  integrity sha512-U5rihytjY3+lGKV3kbrVlT+buSQNc6gxSQIQ+McR7icb5hiXJmfwNeaSor7wEkv4SdKe2vGLcYlWoBwLvCYAHw==
+  version "2026.10510.1"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.10510.1/bfa79ee2a6aef3216007a61e883a82bfe7cf30a7#bfa79ee2a6aef3216007a61e883a82bfe7cf30a7"
+  integrity sha512-I/LER85TnMCxgNhxW3imVHyNmtoNrH6ahsBBKIvyzXrCdWAVleb1mADyT9RXc0QcN6mnelvuHgs9eFESThpiZg==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,10 +822,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@icco/react-common@^2026.430.1":
-  version "2026.430.3"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.430.3/b7829a20bbfb1ba58fb83ceaee783a136c8951b9#b7829a20bbfb1ba58fb83ceaee783a136c8951b9"
-  integrity sha512-d67dBml2zRYSMNQqLQEG6gNsemitlQ4oJu2DrcRFP7XY9R/uyIGRAPvFuU2HBOr45Nq9aXZpTgMctQK8Xvhowg==
+"@icco/react-common@^2026.510.2":
+  version "2026.510.2"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.510.2/148b54b2cb740bc174ba2550796c8cfa82d64a0d#148b54b2cb740bc174ba2550796c8cfa82d64a0d"
+  integrity sha512-U5rihytjY3+lGKV3kbrVlT+buSQNc6gxSQIQ+McR7icb5hiXJmfwNeaSor7wEkv4SdKe2vGLcYlWoBwLvCYAHw==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"


### PR DESCRIPTION
## Summary

- Bumps `@icco/react-common` to `^2026.510.2` (icco/react-common#106), which adds icon support to `SiteHeader` nav links and collapses labels to icon-only below the `md` breakpoint.
- Adds Heroicons to the Stats / Tags / About nav links via the new `icon` prop, so the header is icon-only on mobile and icon + label on tablet/desktop.

